### PR TITLE
Use correct filenames in genrated nix files

### DIFF
--- a/src/pypi2nix/cli.py
+++ b/src/pypi2nix/cli.py
@@ -84,9 +84,11 @@ def main(input_file, nix_path, extra_build_inputs):
             write("let")
             write("  pkgs = import <nixpkgs> { };")
             write("  pythonPackages = pkgs.python27Packages;")
-            write("  generated = import ./sentry_generated.nix { "
-                  "inherit pkgs self pythonPackages; };")
-            write("  overrides = import ./sentry_overwrite.nix { "
-                  "inherit pkgs self generated pythonPackages; };")
+            write("  generated = import ./{generate_file} {{ "
+                  "inherit pkgs self pythonPackages; }};".format(
+                      generate_file=generate_file))
+            write("  overrides = import ./{overwrite_file} {{ "
+                  "inherit pkgs self generated pythonPackages; }};".format(
+                      overwrite_file=overwrite_file))
             write("  self = generated // overrides;")
             write("in self")


### PR DESCRIPTION
Point to the correct "_generated.nix" and "_overwrite.nix".

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/garbas/pypi2nix/17)
<!-- Reviewable:end -->
