### PR TITLE
Add --setup-requires option to install pip packages before building wheels.

### DIFF
--- a/src/pypi2nix/cli.py
+++ b/src/pypi2nix/cli.py
@@ -76,6 +76,11 @@ import pypi2nix.utils
               type=str,
               help=u'location/url to editable locations',
               )
+@click.option('-s', '--setup-requires',
+              default=None,
+              help=u'Extra Python dependencies needed before the installation'
+                   u'to build wheels.'
+              )
 def main(version,
          verbose,
          nix_path,
@@ -87,6 +92,7 @@ def main(version,
          requirements,
          buildout,
          editable,
+         setup_requires,
          ):
     """SPECIFICATION should be requirements.txt (output of pip freeze).
     """
@@ -114,6 +120,9 @@ def main(version,
 
     if extra_build_inputs:
         extra_build_inputs = extra_build_inputs.split(' ')
+
+    if setup_requires:
+        setup_requires = setup_requires.split(' ')
 
     if not cache_dir:
         cache_dir = os.path.join(tmp_dir, 'cache')
@@ -200,7 +209,7 @@ def main(version,
     click.echo('pypi2nix v{} running ...'.format(pypi2nix_version))
     click.echo('')
 
-    if buildout:
+    if buildout or setup_requires:
         click.echo('Stage0: Generating requirements.txt from buildout configuration ...')
         buildout_requirements = pypi2nix.stage0.main(
             verbose=verbose,
@@ -210,8 +219,10 @@ def main(version,
             extra_build_inputs=extra_build_inputs,
             python_version=pypi2nix.utils.PYTHON_VERSIONS[python_version],
             nix_path=nix_path,
+            setup_requires=setup_requires,
         )
-        requirements_files.append(buildout_requirements)
+        if buildout_requirements:
+            requirements_files.append(buildout_requirements)
 
     if editable:
         editable_file = os.path.join(tmp_dir, 'editable.txt')

--- a/src/pypi2nix/pip.nix
+++ b/src/pypi2nix/pip.nix
@@ -34,7 +34,7 @@ in pkgs.stdenv.mkDerivation rec {
 
     mkdir -p ${project_dir}/wheel ${project_dir}/wheelhouse
 
-    PYTHONPATH=${pypi2nix_bootstrap}/extra:$PYTHONPATH \
+    PYTHONPATH=${pypi2nix_bootstrap}/extra:${project_dir}/setup_requires:$PYTHONPATH \
       pip wheel \
         ${builtins.concatStringsSep" "(map (x: "-r ${x} ") requirements_files)} \
         --wheel-dir ${project_dir}/wheel \

--- a/src/pypi2nix/stage0.py
+++ b/src/pypi2nix/stage0.py
@@ -10,6 +10,7 @@ def main(verbose,
          buildout_cache_dir,
          extra_build_inputs,
          python_version,
+         setup_requires=None,
          nix_path=None,
          ):
     """ Converts buildout.cfg specifiation into requirements.txt file
@@ -23,6 +24,7 @@ def main(verbose,
             buildout_cache_dir=buildout_cache_dir,
             extra_build_inputs=extra_build_inputs,
             python_version=python_version,
+            setup_requires=setup_requires,
         )),
         nix_path=nix_path \
             and ' '.join('-I {}'.format(i) for i in nix_path) \
@@ -36,4 +38,5 @@ def main(verbose,
         raise click.ClickException(
             u'While trying to run the command something went wrong.')
 
-    return os.path.join(project_dir, 'buildout_requirements.txt')
+
+    return buildout_file and os.path.join(project_dir, 'buildout_requirements.txt') or None


### PR DESCRIPTION
Needed to build scipy.
I tested it with this command in **nix-shell**:

```
TMPDIR=../tmp pypi2nix -v -V "3.5" -e scipy --pre-install "numpy" -E "openblas"
```

Pip does not complain anymore about numpy, but fails on a missing library (openblas), even if this lib. is set in the extra build inputs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/garbas/pypi2nix/82)
<!-- Reviewable:end -->
