### PR TITLE
Fix #87 and default.nix

### DIFF
--- a/src/pypi2nix/pip.nix
+++ b/src/pypi2nix/pip.nix
@@ -65,6 +65,7 @@ in pkgs.stdenv.mkDerivation rec {
 
     ${numpySiteCfg}
     ${scriptRequires}
+    export SOURCE_DATE_EPOCH=315532800
 
     mkdir -p ${project_dir}/wheel ${project_dir}/wheelhouse
 


### PR DESCRIPTION
This PR has two small commits to fix #87 and <strike>make installation a little
bit easier by allowing the default.nix to be used with `callPackage`</strike>.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/garbas/pypi2nix/88)
<!-- Reviewable:end -->
