### PR TITLE
Add support for passing extra env variables

### DIFF
--- a/src/pypi2nix/cli.py
+++ b/src/pypi2nix/cli.py
@@ -51,6 +51,12 @@ import pypi2nix.utils
               help=u'Extra build dependencies needed for installation of '
                    u'required python packages.'
               )
+@click.option('-N', '--extra-env',
+              default='',
+              help=u'Extra environment variables needed for installation of'
+              u'required python pakcages.'
+              u'Example: "LANG=en_US.UTF-8 FOO_OPTS=xyz"'
+              )
 @click.option('-T', '--enable-tests',
               is_flag=True,
               help=u'Enable tests in generated packages.'
@@ -97,6 +103,7 @@ def main(version,
          basename,
          cache_dir,
          extra_build_inputs,
+         extra_env,
          enable_tests,
          python_version,
          requirements,
@@ -260,6 +267,7 @@ def main(version,
         python_version=pypi2nix.utils.PYTHON_VERSIONS[python_version],
         nix_path=nix_path,
         setup_requires=setup_requires,
+        extra_env=extra_env,
     )
 
     click.echo('Stage2: Extracting metadata from pypi.python.org ...')

--- a/src/pypi2nix/pip.nix
+++ b/src/pypi2nix/pip.nix
@@ -5,6 +5,7 @@
 , pip_build_dir
 , python_version
 , extra_build_inputs ? []
+, extra_env ? ""
 , setup_requires ? []
 }:
 
@@ -45,7 +46,7 @@ let
           --find-links ${wheel_cache_dir} \
           --cache-dir ${download_cache_dir} \
           --build ${pip_build_dir} \
-          --no-binary :all: 
+          --no-binary :all:
     '';
 
 in pkgs.stdenv.mkDerivation rec {
@@ -74,7 +75,7 @@ in pkgs.stdenv.mkDerivation rec {
     mkdir -p ${project_dir}/wheel ${project_dir}/wheelhouse
 
     PYTHONPATH=${pypi2nix_bootstrap}/extra:${project_dir}/setup_requires:$PYTHONPATH \
-      pip wheel \
+      ${extra_env} pip wheel \
         ${builtins.concatStringsSep" "(map (x: "-r ${x} ") requirements_files)} \
         --wheel-dir ${project_dir}/wheel \
         --find-links ${wheel_cache_dir} \

--- a/src/pypi2nix/stage1.py
+++ b/src/pypi2nix/stage1.py
@@ -21,6 +21,7 @@ def main(verbose,
          nix_path=None,
          nix_shell='nix-shell',
          setup_requires=[],
+         extra_env='',
          ):
     """Create a complete (pip freeze) requirements.txt and a wheelhouse from
        a user provided requirements.txt.
@@ -36,6 +37,7 @@ def main(verbose,
             wheel_cache_dir=wheel_cache_dir,
             pip_build_dir=pip_build_dir,
             extra_build_inputs=extra_build_inputs,
+            extra_env=extra_env,
             python_version=python_version,
             setup_requires=setup_requires,
         )),


### PR DESCRIPTION
Bascause some funky `setup.py` files take arguments from the environment. 
As far as I understand pypi2nix runs a pure nix-shell exactly to avoid variables like this so I created a new flag to explicitly pass settings in.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/garbas/pypi2nix/97)
<!-- Reviewable:end -->
