### PR TITLE
Add generate-overlay option

### DIFF
--- a/src/pypi2nix/cli.py
+++ b/src/pypi2nix/cli.py
@@ -96,6 +96,10 @@ import pypi2nix.utils
               help=u'Extra Python dependencies needed before the installation'
                    u'to build wheels.'
               )
+@click.option('--generate-overlay',
+              is_flag=True,
+              help=u'If we should generate an overlay file, instead of the classic expression.'
+              )
 def main(version,
          verbose,
          nix_shell,
@@ -110,6 +114,7 @@ def main(version,
          buildout,
          editable,
          setup_requires,
+         generate_overlay,
          ):
     """SPECIFICATION should be requirements.txt (output of pip freeze).
     """
@@ -319,6 +324,7 @@ def main(version,
         enable_tests=enable_tests,
         python_version=pypi2nix.utils.PYTHON_VERSIONS[python_version],
         current_dir=current_dir,
+        generate_overlay=generate_overlay,
     )
 
     click.echo('')

--- a/src/pypi2nix/cli.py
+++ b/src/pypi2nix/cli.py
@@ -98,7 +98,8 @@ import pypi2nix.utils
               )
 @click.option('--generate-overlay',
               is_flag=True,
-              help=u'If we should generate an overlay file, instead of the classic expression.'
+              help=u'If we should generate an overlay file, instead of'
+                   u'the classic expression.'
               )
 def main(version,
          verbose,

--- a/src/pypi2nix/stage3.py
+++ b/src/pypi2nix/stage3.py
@@ -88,7 +88,8 @@ OVERLAY_NIX = '''
 
 self: pkgs:
 let
-  python.mkDerivation = (import "${toString pkgs.path}/pkgs/top-level/python-packages.nix" {
+  python.mkDerivation =
+  (import "${toString pkgs.path}/pkgs/top-level/python-packages.nix" {
     inherit pkgs;
     inherit (pkgs) stdenv;
     python = pkgs.%(python_version)s;


### PR DESCRIPTION
Hi, do you think this makes sense?

The idea is that this could then be used like

```nix
let
  pkgs = import <nixpkgs> {
      overlays=[(import ./requirements.nix)];
      };
in
  pkgs.Jinja2
```

(Though personally I just pin the nixpkgs in a `channel.nix` like this:
```nix
import (fetchTarball
    "https://github.com/NixOS/nixpkgs-channels/archive/f1ba2c8.tar.gz"
) {
    overlays=[(import ./requirements.nix)];
}
```
)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/garbas/pypi2nix/113)
<!-- Reviewable:end -->
