### PR TITLE
Reformat .travis.yml, 80 characters rule

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,22 +26,42 @@ matrix:
 before_install:
   - nix-env -iA nixpkgs.cacert -p result-cacert
   - export SSL_CERT_FILE=$PWD/result-cacert/etc/ssl/certs/ca-bundle.crt
-  - sudo mkdir -p /etc/ssl/certs/ && sudo rm -f /etc/ssl/certs/ca-certificates.crt && sudo ln -s $PWD/result-cacert/etc/ssl/certs/ca-bundle.crt /etc/ssl/certs/ca-certificates.crt
-  - echo 'binary-caches = https://cache.nixos.org/ https://travis.garbas.si/pypi2nix/' | sudo tee -a /etc/nix/nix.conf > /dev/null
-  - if [ "$TRAVIS_PULL_REQUEST" = "false" -a "$TRAVIS_BRANCH" = "master" ]; then
-      openssl aes-256-cbc -K $encrypted_0cfcc1944c73_key -iv $encrypted_0cfcc1944c73_iv -in deploy_rsa.enc -out deploy_rsa -d;
+  - >
+    sudo mkdir -p /etc/ssl/certs/ &&
+    sudo rm -f /etc/ssl/certs/ca-certificates.crt &&
+    sudo ln -s \
+      $PWD/result-cacert/etc/ssl/certs/ca-bundle.crt \
+      /etc/ssl/certs/ca-certificates.crt
+  - >
+    echo 'binary-caches = https://cache.nixos.org/ https://travis.garbas.si/pypi2nix/' |
+    sudo tee -a /etc/nix/nix.conf > /dev/null
+  - >
+    if [ "$TRAVIS_PULL_REQUEST" = "false" -a
+         "$TRAVIS_BRANCH" = "master" ]; then
+      openssl aes-256-cbc
+        -K $encrypted_0cfcc1944c73_key
+        -iv $encrypted_0cfcc1944c73_iv
+        -in deploy_rsa.enc
+        -out deploy_rsa
+        -d;
       eval "$(ssh-agent -s)";
       chmod 600 $TRAVIS_BUILD_DIR/deploy_rsa;
       ssh-add $TRAVIS_BUILD_DIR/deploy_rsa;
     fi
 script:
   - cd examples && make $EXAMPLE && cd ..
-  - if [ "$TRAVIS_PULL_REQUEST" = "false" -a "$TRAVIS_BRANCH" = "master" ]; then
+  - if [ "$TRAVIS_PULL_REQUEST" = "false" -a
+         "$TRAVIS_BRANCH" = "master" ]; then
       mkdir nars/;
       nix-push --dest "$PWD/nars/" --force ./examples/$EXAMPLE;
     fi
 after_success:
-  - if [ "$TRAVIS_PULL_REQUEST" = "false" -a "$TRAVIS_BRANCH" = "master" ]; then
-      rsync -avh --ignore-existing $TRAVIS_BUILD_DIR/nars/ travis@garbas.si:/var/travis/pypi2nix/;
+  - >
+    if [ "$TRAVIS_PULL_REQUEST" = "false" -a
+         "$TRAVIS_BRANCH" = "master" ]; then
+      rsync
+        -avh
+        --ignore-existing
+        $TRAVIS_BUILD_DIR/nars/
+        travis@garbas.si:/var/travis/pypi2nix/;
     fi
-


### PR DESCRIPTION
Use multi line yml strings to break newlines.  Newlines in yaml
multi line strings are replaced with a space character, so no
backslashes are required.

This should improve readability a bit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/garbas/pypi2nix/114)
<!-- Reviewable:end -->
