### PR TITLE
Pass nix-prefetch-git and nix-prefetch-hg in shell.nix to default.nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -8,5 +8,6 @@ let
   pythonPackages = builtins.getAttr "python${pythonVersion}Packages" pkgs;
 in import ./default.nix {
   inherit src pythonPackages;
-  inherit (pkgs) stdenv fetchurl zip makeWrapper nix nix-prefetch-scripts;
+  inherit (pkgs) stdenv fetchurl zip makeWrapper nix
+    nix-prefetch-git nix-prefetch-hg;
 }


### PR DESCRIPTION
This should fix ``nix-shell`` on nixos-unstable

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/garbas/pypi2nix/118)
<!-- Reviewable:end -->
