### PR TITLE
Enable relative paths for -O option

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -233,7 +233,7 @@ tornado: tornado.nix
 
 tornado.nix: tornado.txt $(PYPI2NIX)
 	echo "generating tornado.nix expressions ..."
-	$(PYPI2NIX) -v --basename tornado -r tornado.txt -I $(NIX_PATH) -V "3.5" -O 'https://raw.githubusercontent.com/garbas/nixpkgs-python/master/overrides.nix' -O 'git+https://github.com/garbas/nixpkgs-python.git#path=overrides.nix&rev=28ecf4bc8cf5e718862159eb1f324ddcf227dfef'
+	$(PYPI2NIX) -v --basename tornado -r tornado.txt -I $(NIX_PATH) -V "3.5" -O 'https://raw.githubusercontent.com/garbas/nixpkgs-python/master/overrides.nix' -O 'git+https://github.com/garbas/nixpkgs-python.git#path=overrides.nix&rev=28ecf4bc8cf5e718862159eb1f324ddcf227dfef' -O './tornado-override/empty.nix'
 
 tornado.txt: tornado-clear
 	echo "-e git+git://github.com/tornadoweb/tornado.git@69253c820df473407c562a227d0ba36df25018ab#egg=tornado" > tornado.txt

--- a/examples/tornado-override/empty.nix
+++ b/examples/tornado-override/empty.nix
@@ -1,0 +1,5 @@
+{ pkgs, python }:
+
+self: super: {
+
+}

--- a/src/pypi2nix/overrides.py
+++ b/src/pypi2nix/overrides.py
@@ -96,7 +96,9 @@ class OverridesGit(object):
 
 def url_to_overrides(url_string):
     url = urlparse(url_string)
-    if url.scheme == 'file' or '':
+    if url.scheme == '':
+        return OverridesFile(url.path)
+    elif url.scheme == 'file':
         return OverridesFile(url.path)
     elif url.scheme == 'http' or url.scheme == 'https':
         return OverridesUrl(url.geturl())


### PR DESCRIPTION
There is a testcase for this in the "tornado" example.

You can now do something like this:

```
pypi2nix -O ./common_overrides.nix -r requirements.nix .....
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/garbas/pypi2nix/119)
<!-- Reviewable:end -->
