### PR TITLE
Python packages nix expressions are written in a separated file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -67,7 +67,9 @@ Once Nix expressions are generated you should be able to see 3 new files:
 - ``requirements_override.nix`` - this is an empty file which is ment to
   override generated nix expressions.
 
-
+- ``requirements_generated.nix`` - is a file which contains the nix
+  expressions generated of all packages. This file can be used outside
+  of pypi2nix, for instance in ``nixpkgs``.
 
 Non-python/system dependencies
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
The python packages nix expressions are written in the file
requirements_generated.nix which can be used outside of pypi2nix. For
instance, this file can be used to describe python dependencies of a
python application in the nixpkgs repository.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/garbas/pypi2nix/127)
<!-- Reviewable:end -->
