### PR TITLE
Replicate meta attributes when overriding

### DIFF
--- a/src/pypi2nix/stage3.py
+++ b/src/pypi2nix/stage3.py
@@ -76,7 +76,8 @@ let
       mkDerivation = pythonPackages.buildPythonPackage;
       packages = pkgs;
       overrideDerivation = drv: f:
-        pythonPackages.buildPythonPackage (drv.drvAttrs // f drv.drvAttrs);
+        pythonPackages.buildPythonPackage (drv.drvAttrs // f drv.drvAttrs // \
+                                           { meta = drv.meta; });
       withPackages = pkgs'':
         withPackages (pkgs // pkgs'');
     };


### PR DESCRIPTION
- fix json report generation by static.nix in nixpkgs-python repo
- allow to generate more complete reports from the final packages set