### PR TITLE
fixes #131

### DIFF
--- a/src/pypi2nix/stage3.py
+++ b/src/pypi2nix/stage3.py
@@ -66,6 +66,8 @@ let
           done
           pushd $out/bin
           ln -s ${pythonPackages.python.executable} python
+          ln -s ${pythonPackages.python.executable} \
+              python%(python_major_version)s
           popd
         '';
         passthru.interpreter = pythonPackages.python;
@@ -243,6 +245,7 @@ def main(packages_metadata,
         common_overrides='\n'.join(common_overrides_expressions),
         paths_to_remove="paths_to_remove.remove(auto_confirm)",
         self_uninstalled="self.uninstalled = paths_to_remove",
+        python_major_version=python_version.replace("python", "")[0],
     )
 
     if not os.path.exists(overrides_file):


### PR DESCRIPTION
This should create a symlink in the interpreter environment that is named `python{2,3}` (depending on python version used to build the env).