### PR TITLE
Implement cli flag shorthand to include overrides from nixpkgs-python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ env:
   - EXAMPLE=tornado
   - EXAMPLE=connexion
   - EXAMPLE=aiohttp
+  - EXAMPLE=flake8
 #  - EXAMPLE=vulnix
 matrix:
   exclude:

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -340,3 +340,22 @@ aiohttp-clear:
 	rm -f aiohttp.txt
 	rm -f aiohttp.nix
 	rm -f aiohttp_frozen.txt
+
+flake8: flake8.nix
+	echo "building and testing flake8..."
+	$(NIX_BUILD) flake8.nix -o flake8 -A interpreter --show-trace --fallback
+	./flake8/bin/python -c 'import flake8'
+	$(NIX_SHELL) flake8.nix -A interpreter --run "python -c 'import flake8'"
+
+flake8.nix: flake8.txt $(PYPI2NIX)
+	echo "generating flake8.nix expressions ..."
+	$(PYPI2NIX) -v --basename flake8 -r flake8.txt -I $(NIX_PATH) -V "3.5" --default-overrides
+
+flake8.txt: flake8-clear
+	echo "flake8" > flake8.txt
+
+flake8-clear:
+	rm -f flake8
+	rm -f flake8.txt
+	rm -f flake8.nix
+	rm -f flake8_frozen.txt

--- a/examples/flake8_override.nix
+++ b/examples/flake8_override.nix
@@ -1,0 +1,5 @@
+{ pkgs, python }:
+
+self: super: {
+
+}

--- a/src/pypi2nix/cli.py
+++ b/src/pypi2nix/cli.py
@@ -104,6 +104,10 @@ import pypi2nix.utils
               help=u'Extra expressions that override generated expressions ' +
                    u'for specific packages',
               )
+@click.option('--default-overrides/--no-default-overrides',
+              default=False,
+              help=u'Apply overrides from "nixpkgs-python" (https://github.com/garbas/nixpkgs-python)', # noqa
+              )
 def main(version,
          verbose,
          nix_shell,
@@ -118,10 +122,19 @@ def main(version,
          buildout,
          editable,
          setup_requires,
-         overrides
+         overrides,
+         default_overrides,
          ):
     """SPECIFICATION should be requirements.txt (output of pip freeze).
     """
+
+    if default_overrides:
+        overrides += tuple([
+            pypi2nix.overrides.OverridesGit(
+                repo_url='https://github.com/garbas/nixpkgs-python.git',
+                path='overrides.nix',
+            )
+        ])
 
     with open(os.path.join(os.path.dirname(__file__), 'VERSION')) as f:
         pypi2nix_version = f.read()


### PR DESCRIPTION
I implemented a command line flag `--default-overrides/--no-default-overrides` to automatically include the overrides of `nixkgs-python`.  The default is currently `False`.  If you feel confident in this feature we could change this to `True`.