### PR TITLE
Make local overrides file (e.g. requirements_override.nix) optional

### DIFF
--- a/src/pypi2nix/stage3.py
+++ b/src/pypi2nix/stage3.py
@@ -89,16 +89,20 @@ let
   generated = self: {
 %(generated_package_nix)s
   };
-  overrides = import %(overrides_file)s { inherit pkgs python; };
+  localOverridesFile = %(overrides_file)s;
+  overrides = import localOverridesFile { inherit pkgs python; };
   commonOverrides = [
 %(common_overrides)s
   ];
+  allOverrides =
+    (if (builtins.pathExists localOverridesFile)
+     then [overrides] else [] ) ++ commonOverrides;
 
 in python.withPackages
    (fix' (pkgs.lib.fold
             extends
             generated
-            ([overrides] ++ commonOverrides)
+            allOverrides
          )
    )
 '''


### PR DESCRIPTION
The idea behind this PR is that if the user **does not provide local overrides** (maybe because of the "default" overrides from [nixpkgs-python](https://github.com/garbas/nixpkgs-python)) the **evaluation of "requirements.nix" does not fail** just because they deleted the empty `requirements_override.nix`.  This will also allow users to use `nixpkgs-python`s `static.nix` without creating empty override files in all the subdirectories.