### PR TITLE
Package pypi2nix for pip

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include src/pypi2nix/*.nix
+include src/pypi2nix/VERSION

--- a/setup.py
+++ b/setup.py
@@ -26,5 +26,11 @@ setup(
             'pypi2nix = pypi2nix.cli:main',
         ],
     },
-    packages = find_packages('src'),
+    packages = ['pypi2nix'],
+    package_dir={'': 'src'},
+    include_package_data=True,
+    install_requires = [
+        'click',
+        'requests',
+    ]
 )


### PR DESCRIPTION
This patch will allow us to install pypi2nix via pip (and therefor also via pypi2nix itself).

This implements #102