### PR TITLE
Change to use cleanSource for path sources

### DIFF
--- a/src/pypi2nix/stage3.py
+++ b/src/pypi2nix/stage3.py
@@ -188,7 +188,8 @@ def main(packages_metadata,
                     )))
         fetch_type = item.get('fetch_type', None)
         if fetch_type == 'path':
-            fetch_expression = './' + os.path.relpath(item['url'], current_dir)
+            fetch_expression = ('pkgs.lib.cleanSource ./' +
+                                os.path.relpath(item['url'], current_dir))
         elif fetch_type == 'fetchgit':
             fetch_expression = 'pkgs.fetchgit { url = "%(url)s"; '\
                 '%(hash_type)s = "%(hash_value)s"; rev = "%(rev)s"; }' % dict(


### PR DESCRIPTION
Any reason, why packages with path sources should not use ``pkgs.lib.cleanSource`` filter from ``nixpkgs``?

https://github.com/NixOS/nixpkgs/blob/master/lib/sources.nix#L29