### PR TITLE
Fix `--default-overrides`

### DIFF
--- a/src/pypi2nix/cli.py
+++ b/src/pypi2nix/cli.py
@@ -130,8 +130,9 @@ def main(version,
 
     if default_overrides:
         overrides += tuple([
-            pypi2nix.overrides.OverridesGit(
-                repo_url='https://github.com/garbas/nixpkgs-python.git',
+            pypi2nix.overrides.OverridesGithub(
+                owner='garbas',
+                repo='nixpkgs-python',
                 path='overrides.nix',
             )
         ])

--- a/src/pypi2nix/overrides.py
+++ b/src/pypi2nix/overrides.py
@@ -63,6 +63,7 @@ class OverridesGit(object):
         'url = "%(url)s"; ' +
         'sha256 = "%(sha256)s"; ' +
         'rev = "%(rev)s"; ' +
+        'fetchSubmodules = false; ' +
         '} ; in import "${src}/%(path)s" { inherit pkgs python; }'
     )
 

--- a/src/pypi2nix/overrides.py
+++ b/src/pypi2nix/overrides.py
@@ -77,6 +77,24 @@ class OverridesGit(object):
         )
 
 
+class OverridesGithub(object):
+    def __init__(self, owner, repo, path, rev=None):
+        self.owner = owner
+        self.repo = repo
+        self.path = path
+        self.rev = rev
+
+    def nix_expression(self):
+        return OverridesGit(
+            repo_url='https://github.com/{owner}/{repo}.git'.format(
+                owner=self.owner,
+                repo=self.repo,
+            ),
+            path=self.path,
+            rev=self.rev
+        ).nix_expression()
+
+
 def url_to_overrides(url_string):
     url = urlparse(url_string)
     if url.scheme == '':


### PR DESCRIPTION
The problem was that nix could not download/verify the source for the `nixpkgs-python` repo when running `pypi2nix --default-overrides ...`.  This PR should fix this problem.

I fixed the problem by setting `fetchSubmodules=false` in the nix expression responsible for downloading the overrides file into the nix store.  This should work not cause any problems for now because we use `nix-prefetch-git` without the `--fetch-submodules` flag.  We should implement an option for that though... :P