### PR TITLE
Implement custom prefetch_github mechanism

### DIFF
--- a/src/pypi2nix/templates/prefetch-github.nix.j2
+++ b/src/pypi2nix/templates/prefetch-github.nix.j2
@@ -1,0 +1,10 @@
+let
+  pkgs = import <nixpkgs> {};
+  src = pkgs.fetchFromGitHub {
+    owner = "{{ owner }}";
+    repo = "{{ repo }}";
+    rev = "{{ rev }}";
+    sha256 = "{{ fake_hash }}";
+  };
+in
+  import "${src}/overrides.nix" { inherit pkgs; python = pkgs.python3; }


### PR DESCRIPTION
We can now make use of fetchFromGithub in our nix expressions.  This means that `--default-overrides` is now implement in in terms of `fetchFromGitHub`.