### PR TITLE
Use nix_prefetch_github packages instead of custom prefetch mechanism

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ matrix:
       env: EXAMPLE=scipy
 before_install:
   - nix-env -iA nixpkgs.cacert -p result-cacert
+  - nix-env -iA nixpkgs.nix-prefetch-git
   - >
     if [ "$TRAVIS_OS_NAME" = 'osx' ]; then
       nix-env -iA nixpkgs.bash;

--- a/requirements.nix
+++ b/requirements.nix
@@ -110,6 +110,21 @@ let
       };
     };
 
+    "attrs" = python.mkDerivation {
+      name = "attrs-18.1.0";
+      src = pkgs.fetchurl { url = "https://files.pythonhosted.org/packages/e4/ac/a04671e118b57bee87dabca1e0f2d3bda816b7a551036012d0ca24190e71/attrs-18.1.0.tar.gz"; sha256 = "e0d0eb91441a3b53dab4d9b743eafc1ac44476296a2053b6ca3af0b139faf87b"; };
+      doCheck = commonDoCheck;
+      buildInputs = commonBuildInputs;
+      propagatedBuildInputs = [
+      self."six"
+    ];
+      meta = with pkgs.stdenv.lib; {
+        homepage = "http://www.attrs.org/";
+        license = licenses.mit;
+        description = "Classes Without Boilerplate";
+      };
+    };
+
     "certifi" = python.mkDerivation {
       name = "certifi-2018.4.16";
       src = pkgs.fetchurl { url = "https://files.pythonhosted.org/packages/4d/9c/46e950a6f4d6b4be571ddcae21e7bc846fcbb88f1de3eff0f6dd0a6be55d/certifi-2018.4.16.tar.gz"; sha256 = "13e698f54293db9f89122b0581843a782ad0934a4fe0172d2a980ba77fc61bb7"; };
@@ -149,9 +164,25 @@ let
       };
     };
 
+    "effect" = python.mkDerivation {
+      name = "effect-0.11.0";
+      src = pkgs.fetchurl { url = "https://files.pythonhosted.org/packages/8a/9a/25a881d1a48847ae95742a30ad0471d9fd71f28a506d30e09dc8cdf4b3ac/effect-0.11.0.tar.gz"; sha256 = "0607530ef589b59f907cfebcb681b5ed4ed56bff1fc2a5de430dcfa72ae1e5e0"; };
+      doCheck = commonDoCheck;
+      buildInputs = commonBuildInputs;
+      propagatedBuildInputs = [
+      self."attrs"
+      self."six"
+    ];
+      meta = with pkgs.stdenv.lib; {
+        homepage = "http://github.com/python-effect/effect/";
+        license = licenses.mit;
+        description = "pure effects for Python";
+      };
+    };
+
     "idna" = python.mkDerivation {
-      name = "idna-2.6";
-      src = pkgs.fetchurl { url = "https://files.pythonhosted.org/packages/f4/bd/0467d62790828c23c47fc1dfa1b1f052b24efdf5290f071c7a91d0d82fd3/idna-2.6.tar.gz"; sha256 = "2c6a5de3089009e3da7c5dde64a141dbc8551d5b7f6cf4ed7c2568d0cc520a8f"; };
+      name = "idna-2.7";
+      src = pkgs.fetchurl { url = "https://files.pythonhosted.org/packages/65/c4/80f97e9c9628f3cac9b98bfca0402ede54e0563b56482e3e6e45c43c4935/idna-2.7.tar.gz"; sha256 = "684a38a6f903c1d71d6d5fac066b58d7768af4de2b832e426ec79c30daa94a16"; };
       doCheck = commonDoCheck;
       buildInputs = commonBuildInputs;
       propagatedBuildInputs = [ ];
@@ -159,6 +190,25 @@ let
         homepage = "https://github.com/kjd/idna";
         license = licenses.bsdOriginal;
         description = "Internationalized Domain Names in Applications (IDNA)";
+      };
+    };
+
+    "nix-prefetch-github" = python.mkDerivation {
+      name = "nix-prefetch-github-1.3";
+      src = pkgs.fetchurl { url = "https://files.pythonhosted.org/packages/1c/50/0d492582fafb03e287c4bc512cd304a6f3fb2b100413bda62e087154fc4e/nix-prefetch-github-1.3.tar.gz"; sha256 = "f8aac41de44ccf3d346dd22f1ccd0f53dc7db01aa29054cdf367890aaa089c56"; };
+      doCheck = commonDoCheck;
+      buildInputs = commonBuildInputs;
+      propagatedBuildInputs = [
+      self."Jinja2"
+      self."attrs"
+      self."click"
+      self."effect"
+      self."requests"
+    ];
+      meta = with pkgs.stdenv.lib; {
+        homepage = "https://github.com/seppeljordan/nix-prefetch-github";
+        license = "GPL3";
+        description = "Prefetch source code from github for nix build tool";
       };
     };
 
@@ -170,6 +220,7 @@ let
       propagatedBuildInputs = [
       self."Jinja2"
       self."click"
+      self."nix-prefetch-github"
       self."requests"
     ];
       meta = with pkgs.stdenv.lib; {
@@ -180,8 +231,8 @@ let
     };
 
     "requests" = python.mkDerivation {
-      name = "requests-2.18.4";
-      src = pkgs.fetchurl { url = "https://files.pythonhosted.org/packages/b0/e1/eab4fc3752e3d240468a8c0b284607899d2fbfb236a56b7377a329aa8d09/requests-2.18.4.tar.gz"; sha256 = "9c443e7324ba5b85070c4a818ade28bfabedf16ea10206da1132edaa6dda237e"; };
+      name = "requests-2.19.0";
+      src = pkgs.fetchurl { url = "https://files.pythonhosted.org/packages/75/27/82da3fa4ea7a8c3526c48eaafe427352ff9c931633b917c2251826a43697/requests-2.19.0.tar.gz"; sha256 = "cc408268d0e21589bcc2b2c248e42932b8c4d112f499c12c92e99e2178a6134c"; };
       doCheck = commonDoCheck;
       buildInputs = commonBuildInputs;
       propagatedBuildInputs = [
@@ -197,9 +248,22 @@ let
       };
     };
 
+    "six" = python.mkDerivation {
+      name = "six-1.11.0";
+      src = pkgs.fetchurl { url = "https://files.pythonhosted.org/packages/16/d8/bc6316cf98419719bd59c91742194c111b6f2e85abac88e496adefaf7afe/six-1.11.0.tar.gz"; sha256 = "70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9"; };
+      doCheck = commonDoCheck;
+      buildInputs = commonBuildInputs;
+      propagatedBuildInputs = [ ];
+      meta = with pkgs.stdenv.lib; {
+        homepage = "http://pypi.python.org/pypi/six/";
+        license = licenses.mit;
+        description = "Python 2 and 3 compatibility utilities";
+      };
+    };
+
     "urllib3" = python.mkDerivation {
-      name = "urllib3-1.22";
-      src = pkgs.fetchurl { url = "https://files.pythonhosted.org/packages/ee/11/7c59620aceedcc1ef65e156cc5ce5a24ef87be4107c2b74458464e437a5d/urllib3-1.22.tar.gz"; sha256 = "cc44da8e1145637334317feebd728bd869a35285b93cbb4cca2577da7e62db4f"; };
+      name = "urllib3-1.23";
+      src = pkgs.fetchurl { url = "https://files.pythonhosted.org/packages/3c/d2/dc5471622bd200db1cd9319e02e71bc655e9ea27b8e0ce65fc69de0dac15/urllib3-1.23.tar.gz"; sha256 = "a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf"; };
       doCheck = commonDoCheck;
       buildInputs = commonBuildInputs;
       propagatedBuildInputs = [

--- a/requirements_frozen.txt
+++ b/requirements_frozen.txt
@@ -1,9 +1,13 @@
+attrs==18.1.0
 certifi==2018.4.16
 chardet==3.0.4
 click==6.7
-idna==2.6
+effect==0.11.0
+idna==2.7
 Jinja2==2.10
 MarkupSafe==1.0
+nix-prefetch-github==1.3
 pypi2nix==1.8.1
-requests==2.18.4
-urllib3==1.22
+requests==2.19.0
+six==1.11.0
+urllib3==1.23

--- a/setup.py
+++ b/setup.py
@@ -33,5 +33,6 @@ setup(
         'click',
         'jinja2',
         'requests',
+        'nix-prefetch-github',
     ]
 )

--- a/src/pypi2nix/overrides.py
+++ b/src/pypi2nix/overrides.py
@@ -85,7 +85,7 @@ class OverridesGithub(object):
         self.rev = rev
 
     def nix_expression(self):
-        rev, sha256 = prefetch_github(self.owner, self.repo, self.rev)
+        prefetch_data = prefetch_github(self.owner, self.repo, self.rev)
         template = ' '.join([
             'let src = pkgs.fetchFromGitHub {{',
             'owner = "{owner}";',
@@ -100,8 +100,8 @@ class OverridesGithub(object):
         return template.format(
             owner=self.owner,
             repo=self.repo,
-            rev=rev,
-            sha256=sha256,
+            rev=prefetch_data['rev'],
+            sha256=prefetch_data['sha256'],
             path=self.path,
         )
 

--- a/src/pypi2nix/utils.py
+++ b/src/pypi2nix/utils.py
@@ -1,14 +1,10 @@
-import os
 import json
-import re
+import os
 import shlex
 import subprocess
-from tempfile import TemporaryDirectory
 
 import click
-import jinja2
-import requests
-
+from nix_prefetch_github import nix_prefetch_github
 
 HERE = os.path.dirname(__file__)
 
@@ -135,61 +131,5 @@ def prefetch_git(url, rev=None):
     return repo_data
 
 
-def get_latest_commit_from_github(owner, repo):
-    url_template = 'https://api.github.com/repos/{owner}/{repo}/commits/master'
-    request_url = url_template.format(
-        owner=owner,
-        repo=repo,
-    )
-    response = requests.get(request_url)
-    return response.json()['sha']
-
-
 def prefetch_github(owner, repo, rev=None):
-    def select_hash_from_match(match):
-        hash_untrimmed = match.group(1) or match.group(2)
-        if hash_untrimmed:
-            return hash_untrimmed[1:-1]
-        else:
-            return None
-
-    calculated_rev = get_latest_commit_from_github(owner, repo)
-    actual_rev = rev or calculated_rev
-    templates_env = jinja2.Environment(
-        loader=jinja2.FileSystemLoader(HERE + '/templates'),
-    )
-    template = templates_env.get_template('prefetch-github.nix.j2')
-    nix_prefetch_code = template.render(
-        owner=owner,
-        repo=repo,
-        rev=actual_rev,
-        fake_hash='1y4ly7lgqm03wap4mh01yzcmvryp29w739fy07zzvz15h2z9x3dv',
-    )
-    with TemporaryDirectory() as temp_dir_name:
-        nix_filename = temp_dir_name + '/prefetch-github.nix'
-        with open(nix_filename, 'w') as f:
-            f.write(nix_prefetch_code)
-        returncode, output = cmd(['nix-build', nix_filename])
-    r = re.compile(
-        "|".join(
-            ["output path .* has .* hash (.*) when .*",
-             "fixed\-output derivation produced path .* with sha256 hash (.*) instead of the expected hash .*", # flake8: noqa: E501
-            ]
-        )
-    )
-    calculated_hash = None
-    for line in output.splitlines():
-        re_match = r.match(line)
-        if not re_match:
-            continue
-        calculated_hash = select_hash_from_match(re_match)
-        break
-    if calculated_hash:
-        return actual_rev, calculated_hash
-    else:
-        raise click.ClickException(
-            (
-                'Internal Error: Calculate hash value for sources '
-                'in github repo {owner}/{repo}.\n\noutput was: {output}'
-            ).format(owner=owner, repo=repo, output=output)
-        )
+    return nix_prefetch_github(owner, repo, rev=rev)


### PR DESCRIPTION
I wrote a small package that implements prefetching from github.  I ran into a lot of problems with the github API rate limit and testing the code, but i think i figured it out okay-ish.  Please have a look at this.  The main advantage of this is that it should prevent travis builds from failing because of github api rate limitations.