### PR TITLE
Allow for an `overrides` argument to `requirements.nix`.

### DIFF
--- a/src/pypi2nix/templates/requirements.nix.j2
+++ b/src/pypi2nix/templates/requirements.nix.j2
@@ -5,7 +5,8 @@
 #   pypi2nix {{ command_arguments }}
 #
 
-{ pkgs ? import <nixpkgs> {}
+{ pkgs ? import <nixpkgs> {},
+  overrides ? ({ pkgs, python }: self: super: {})
 }:
 
 let
@@ -85,13 +86,16 @@ let
 {{ generated_package_nix }}
   };
   localOverridesFile = {{ overrides_file }};
-  overrides = import localOverridesFile { inherit pkgs python; };
+  localOverrides = import localOverridesFile { inherit pkgs python; };
   commonOverrides = [
     {{ common_overrides }}
   ];
+  paramOverrides = [
+    (overrides { inherit pkgs python; })
+  ];
   allOverrides =
     (if (builtins.pathExists localOverridesFile)
-     then [overrides] else [] ) ++ commonOverrides;
+     then [localOverrides] else [] ) ++ commonOverrides ++ paramOverrides;
 
 in python.withPackages
    (fix' (pkgs.lib.fold


### PR DESCRIPTION
This is a bit like that from nixpkgs's `pythonPackages` argument.
However, this one also has a `{ pkgs, python }` outer layer for
consistency with other requirements overrides.

Fix latter part of #195