### PR TITLE
examples: add failing test with includes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@
 /examples/empy.nix
 /examples/empy_override.nix
 /examples/flake8
+/examples/flake8-includes
+/examples/flake8-includes.nix
+/examples/flake8-includes_override.nix
 /examples/flake8.nix
 /examples/flake8_override.nix
 /examples/ldap

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -19,7 +19,7 @@ endif
 	connexion \
 	empy \
 	flake8 \
-	flake8-includes
+	flake8-includes \
 	ldap \
 	lektor \
 	mercurial \

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -19,6 +19,7 @@ endif
 	connexion \
 	empy \
 	flake8 \
+	flake8-includes
 	ldap \
 	lektor \
 	mercurial \
@@ -34,6 +35,7 @@ all: \
 	connexion \
 	empy \
 	flake8 \
+	flake8-includes \
 	ldap \
 	lektor \
 	mercurial \
@@ -49,6 +51,7 @@ clear: \
 	connexion-clear \
 	empy-clear \
 	flake8-clear \
+	flake8-includes-clear \
 	ldap-clear \
 	lektor-clear \
 	mercurial-clear \
@@ -213,6 +216,28 @@ flake8-clear:
 	rm -f flake8.txt
 	rm -f flake8.nix
 	rm -f flake8_frozen.txt
+
+
+#------------------------------------------------------------------------------
+
+
+flake8-includes: flake8-includes.nix
+	echo "building and testing flake8-includes..."
+	$(NIX_BUILD) flake8-includes.nix -o flake8-includes -A interpreter --show-trace --fallback
+	./flake8-includes/bin/python -c 'import flake8'
+	$(NIX_SHELL) flake8-includes.nix -A interpreter --run "python -c 'import flake8'"
+
+flake8-includes.nix: flake8-includes.txt $(PYPI2NIX)
+	echo "generating flake8-includes.nix expressions ..."
+	$(PYPI2NIX) -v \
+		-I $(NIX_PATH) \
+		-V "3.5" \
+		-r flake8-includes.txt
+flake8-includes.txt: flake8-includes-clear flake8.txt
+	echo "-r flake8.txt" > flake8-includes.txt
+
+flake8-includes-clear:
+	rm -f flake8-includes.txt
 
 
 #------------------------------------------------------------------------------

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -223,16 +223,17 @@ flake8-clear:
 
 flake8-includes: flake8-includes.nix
 	echo "building and testing flake8-includes..."
-	$(NIX_BUILD) flake8-includes.nix -o flake8-includes -A interpreter --show-trace --fallback
+	$(NIX_BUILD) flake8-includes.nix -o flake8-includes interpreter
 	./flake8-includes/bin/python -c 'import flake8'
-	$(NIX_SHELL) flake8-includes.nix -A interpreter --run "python -c 'import flake8'"
+	$(NIX_SHELL) flake8-includes.nix interpreter --command python -c 'import flake8'
 
 flake8-includes.nix: flake8-includes.txt $(PYPI2NIX)
 	echo "generating flake8-includes.nix expressions ..."
 	$(PYPI2NIX) -v \
 		-I $(NIX_PATH) \
 		-V "3.5" \
-		--default-overrides \
+		-e pytest-runner \
+		-e setuptools-scm \
 		--basename flake8-includes \
 		-r flake8-includes.txt
 flake8-includes.txt: flake8-includes-clear flake8.txt

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -232,6 +232,8 @@ flake8-includes.nix: flake8-includes.txt $(PYPI2NIX)
 	$(PYPI2NIX) -v \
 		-I $(NIX_PATH) \
 		-V "3.5" \
+		--default-overrides \
+		--basename flake8-includes \
 		-r flake8-includes.txt
 flake8-includes.txt: flake8-includes-clear flake8.txt
 	echo "-r flake8.txt" > flake8-includes.txt


### PR DESCRIPTION
This adds a test trying to build a requirements txt file simply
containing a `-e other_file.txt`.
We (ab)use the existing flake8.txt file for that.

pypi2nix fails with
> Could not open requirements file: [Errno 2] No such file or directory: '/run/user/1000/pypi2nix/8db5a60850956d906d64b8efa2f5cab0/flake8.txt'
as the referenced file is not copied into the rundir.

failing example as requested in #156.