### PR TITLE
Set checkPhase and installCheckPhase to "" when generating expressions

### DIFF
--- a/src/pypi2nix/templates/generated.nix.j2
+++ b/src/pypi2nix/templates/generated.nix.j2
@@ -2,6 +2,8 @@
       name = "{{ name }}-{{ version }}";
       src = {{ fetch_expression }};
       doCheck = commonDoCheck;
+      checkPhase = "";
+      installCheckPhase = "";
       buildInputs = commonBuildInputs;
       propagatedBuildInputs = {{ propagatedBuildInputs }};
       meta = with pkgs.stdenv.lib; {


### PR DESCRIPTION
We had a lot of build failures because in nixpkgs for some reason the doCheck flag was ignored.  This lead to a lot of build
failures.  This patch will fix this issue by setting the checkPhase and installCheckPhase derivation inputs to "".