### PR TITLE
Re-raise exception instead of raising a new one to avoid messing with the stack trace

### DIFF
--- a/src/pypi2nix/stage2.py
+++ b/src/pypi2nix/stage2.py
@@ -458,6 +458,6 @@ def main(verbose, wheels, requirements_files, wheel_cache_dir, index=INDEX_URL,
     except Exception as e:
         if verbose == 0:
             click.echo(output)
-        raise e
+        raise
 
     return metadata


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/nix/store/ak7wj03wmcg3gqzjxymb8c2yvaxqhl52-pypi2nix-1.8.1/bin/.pypi2nix-wrapped", line 3, in <module>
    pypi2nix.cli.main()
  File "/nix/store/2ky0iqg5mdg9z464qrswm354l13fca1r-python3.6-click-6.7/lib/python3.6/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/nix/store/2ky0iqg5mdg9z464qrswm354l13fca1r-python3.6-click-6.7/lib/python3.6/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/nix/store/2ky0iqg5mdg9z464qrswm354l13fca1r-python3.6-click-6.7/lib/python3.6/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/nix/store/2ky0iqg5mdg9z464qrswm354l13fca1r-python3.6-click-6.7/lib/python3.6/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/nix/store/61zmdvv197s4k6waplwgcdbsh24qym8d-python3.6-pypi2nix-1.8.1/lib/python3.6/site-packages/pypi2nix/cli.py", line 335, in main
    sources=sources,
  File "/nix/store/61zmdvv197s4k6waplwgcdbsh24qym8d-python3.6-pypi2nix-1.8.1/lib/python3.6/site-packages/pypi2nix/stage2.py", line 461, in main
    raise e
  File "/nix/store/61zmdvv197s4k6waplwgcdbsh24qym8d-python3.6-pypi2nix-1.8.1/lib/python3.6/site-packages/pypi2nix/stage2.py", line 457, in main
    verbose, index))
  File "/nix/store/61zmdvv197s4k6waplwgcdbsh24qym8d-python3.6-pypi2nix-1.8.1/lib/python3.6/site-packages/pypi2nix/stage2.py", line 372, in process_wheel
    r.raise_for_status()  # TODO: handle this nicer
  File "/nix/store/4b1s3n1sr4n4mlgcsi00h83kwam0rs93-python3.6-requests-2.19.0/lib/python3.6/site-packages/requests/models.py", line 939, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 404 Client Error: Not Found for url: https://pypi.org/project/firefox-code-coverage/json/
```

Without this change, the stack trace is confusing as Python thinks the exception is coming from this line.