### PR TITLE
Support 'MPL2' too as a short name for the Mozilla Public License

### DIFF
--- a/src/pypi2nix/stage2.py
+++ b/src/pypi2nix/stage2.py
@@ -165,7 +165,7 @@ def find_license(item):
         elif license in ['GNU Lesser General Public License (LGPL), Version 3',
                          'LGPL']:
             license = "licenses.lgpl3"
-        elif license in ['MPL 2.0', 'MPL 2.0 (Mozilla Public License)', 'MPL-2.0']:
+        elif license in ['MPL2', 'MPL 2.0', 'MPL 2.0 (Mozilla Public License)', 'MPL-2.0']:
             license = "licenses.mpl20"
         elif license in ['Python Software Foundation License']:
             license = "licenses.psfl"


### PR DESCRIPTION
Some projects are using this short name.