### PR TITLE
Revert disabling checkPhase and installCheckPhase

### DIFF
--- a/src/pypi2nix/templates/generated.nix.j2
+++ b/src/pypi2nix/templates/generated.nix.j2
@@ -2,8 +2,6 @@
       name = "{{ name }}-{{ version }}";
       src = {{ fetch_expression }};
       doCheck = commonDoCheck;
-      checkPhase = "";
-      installCheckPhase = "";
       buildInputs = commonBuildInputs ++ {{ buildInputs }};
       propagatedBuildInputs = {{ propagatedBuildInputs }};
       meta = with pkgs.stdenv.lib; {


### PR DESCRIPTION
This reverts commit d4619c8cf374016dba584a450c6e05e78c492d29.

From the commit message:

> We had a lot of build failures because in nixpkgs for some reason the doCheck flag was ignored.

Working around a `nixpkgs` issue from `pypi2nix` is clearly not the right approach and it should instead be fixed in `nixpkgs`, which apparently is fixed already (at least for NixOS 18.09 the `doCheck` attribute wasn't ignored, likewise for `nixpkgs` master).

The workaround also has made the `-T` commandline argument of `pypi2nix` useless and basically rendered it into a no-op because `checkPhase` and `installCheckPhase` were disabled unconditionally.