### PR TITLE
Fix nativeBuildInputs in mkDerivation

### DIFF
--- a/src/pypi2nix/templates/requirements.nix.j2
+++ b/src/pypi2nix/templates/requirements.nix.j2
@@ -75,7 +75,9 @@ let
       __old = pythonPackages;
       inherit interpreter;
       inherit interpreterWithPackages;
-      mkDerivation = args: pythonPackages.buildPythonPackage (args // { nativeBuildInputs = args.buildInputs; });
+      mkDerivation = args: pythonPackages.buildPythonPackage (args // {
+        nativeBuildInputs = (args.nativeBuildInputs or []) ++ args.buildInputs;
+      });
       packages = pkgs;
       overrideDerivation = drv: f:
         pythonPackages.buildPythonPackage (


### PR DESCRIPTION
Regression introduced in 9b2870a377ac3bd6d921d81c4b5ccdf0f023d5e4.

The reason why I call it a regression is because since that commit, `buildInputs` equals to `nativeBuildInputs` and passing any `nativeBuildInputs` to `mkDerivation` will just silently discard those packages and/or hooks.

I haven't found out the reason for the aliasing because the commit message wasn't very helpful, but discarding `nativeBuildInputs` is probably not what the author intended.

So now, we're just *appending* all of `buildInputs` to `nativeBuildInputs` instead of discarding its previous contents.