### PR TITLE
Don't invoke rc file when executing commands

### DIFF
--- a/src/pypi2nix/nix.py
+++ b/src/pypi2nix/nix.py
@@ -48,7 +48,7 @@ class Nix:
             "nix-shell",
             create_command_options(nix_arguments)
             + (["--pure"] if pure else [])
-            + [derivation_path, "--command", command],
+            + [derivation_path, "--run", command],
         )
         return output
 


### PR DESCRIPTION
This speeds up the entire process and prevents output of login shells breaking json parsing.